### PR TITLE
Fix image size in members page

### DIFF
--- a/themes/fikaworks/layouts/members/list.html
+++ b/themes/fikaworks/layouts/members/list.html
@@ -19,7 +19,7 @@
               {{- if $src }}
                 {{- $small := $src.Fit "320x320" }}
                 <img
-                  class="w-100 h-100 rounded-full mx-auto {{ .Params.member_status }} membership"
+                  class="w-40 h-40 rounded-full mx-auto object-cover {{ .Params.member_status }} membership"
                   alt="{{ .Title }}"
                   src="{{ $small.RelPermalink }}"
                 />


### PR DESCRIPTION
One-line fix to make all profile images of equal size

Before:

![fika_before](https://user-images.githubusercontent.com/3543138/160154516-f909eeb9-b473-48d3-941e-f1a509394a53.png)

After:

![fika_after](https://user-images.githubusercontent.com/3543138/160154514-7de6495e-9645-4a8a-aa16-a197f4702e8e.png)

